### PR TITLE
bugfix for odps_rtp_input

### DIFF
--- a/easy_rec/python/model/easy_rec_estimator.py
+++ b/easy_rec/python/model/easy_rec_estimator.py
@@ -248,6 +248,7 @@ class EasyRecEstimator(tf.estimator.Estimator):
       var_list = (
           tf.get_collection(tf.GraphKeys.GLOBAL_VARIABLES) +
           tf.get_collection(tf.GraphKeys.SAVEABLE_OBJECTS))
+      initialize_var_list = [x for x in var_list if "WorkQueue" not in str(type(x))]
       # early_stop flag will not be saved in checkpoint
       # and could not be restored from checkpoint
       early_stop_var = find_early_stop_var(var_list)
@@ -266,7 +267,7 @@ class EasyRecEstimator(tf.estimator.Estimator):
               max_to_keep=self.train_config.keep_checkpoint_max),
           local_init_op=local_init_op,
           ready_for_local_init_op=tf.report_uninitialized_variables(
-              var_list=var_list))
+              var_list=initialize_var_list))
       # saver hook
       saver_hook = estimator_utils.CheckpointSaverHook(
           checkpoint_dir=self.model_dir,


### PR DESCRIPTION
model variable initialize would check all element type in var_list, object workqueue has no attribute dtype, so we should delete it from var_list.

Bug reproduce:
set input_type to OdpsRTPInput, train on pai, will report error.
![截屏2021-10-31 下午6 01 39](https://user-images.githubusercontent.com/16728136/139613281-ce135256-c8c0-4afb-b9ca-ab0696905de0.png)