### PR TITLE
[bugfix]: fix markdown version

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -3,4 +3,5 @@ commonmark==0.8.1
 recommonmark==0.6.0
 sphinx==4.5.0
 sphinx_markdown_tables==0.0.15
+Markdown==3.2.2
 sphinx_rtd_theme


### PR DESCRIPTION
fix markdown version, which could be incompatible with sphinx_markdown_tables