### PR TITLE
[bugfix] Fix for importing the estimator_export decorator from tensorflow_estimator

### DIFF
--- a/easy_rec/python/compat/early_stopping.py
+++ b/easy_rec/python/compat/early_stopping.py
@@ -33,7 +33,7 @@ from tensorflow.python.summary import summary_iterator
 from tensorflow.python.training import basic_session_run_hooks
 from tensorflow.python.training import session_run_hook
 from tensorflow.python.training import training_util
-from tensorflow.python.util.tf_export import estimator_export
+from tensorflow_estimator.python.estimator.estimator_export import estimator_export
 
 from easy_rec.python.utils.config_util import parse_time
 from easy_rec.python.utils.load_class import load_by_path


### PR DESCRIPTION
Due to a recent commit in TensorFlow (https://github.com/tensorflow/tensorflow/commit/3837d0f28cb1812878dd8b21aecf283b06f5617c) that removes support for the `estimator_export` decorator from `tf_export` inside TensorFlow, several models such as MMoE fail to run with the following error: 
_ImportError: cannot import name 'estimator_export' from 'tensorflow.python.util.tf_export'_. 

As a solution, 'estimator_export' now needs to be imported from within the `tensorflow_estimator` package itself.