### PR TITLE
Support macOS & Windows and Support Tensorflow >= 2.12.0

### DIFF
--- a/.git_oss_config_pub
+++ b/.git_oss_config_pub
@@ -1,6 +1,6 @@
 bucket_name = easyrec
 git_oss_data_dir = data/git_oss_sample_data
 host = oss-cn-beijing.aliyuncs.com
-git_oss_cache_dir = ${TMPDIR}/${PROJECT_NAME}/.git_oss_cache
+git_oss_cache_dir = ${TMPDIR}${PROJECT_NAME}/.git_oss_cache
 git_oss_private_config = ~/.git_oss_config_private
 accl_endpoint = oss-accelerate.aliyuncs.com

--- a/.git_oss_config_pub
+++ b/.git_oss_config_pub
@@ -1,6 +1,6 @@
 bucket_name = easyrec
 git_oss_data_dir = data/git_oss_sample_data
 host = oss-cn-beijing.aliyuncs.com
-git_oss_cache_dir = ${TMPDIR}${PROJECT_NAME}/.git_oss_cache
+git_oss_cache_dir = ${TMPDIR}/${PROJECT_NAME}/.git_oss_cache
 git_oss_private_config = ~/.git_oss_config_private
 accl_endpoint = oss-accelerate.aliyuncs.com

--- a/easy_rec/python/compat/early_stopping.py
+++ b/easy_rec/python/compat/early_stopping.py
@@ -22,6 +22,8 @@ import os
 import threading
 import time
 
+import tensorflow as tf
+from distutils.version import LooseVersion
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import init_ops
@@ -33,10 +35,14 @@ from tensorflow.python.summary import summary_iterator
 from tensorflow.python.training import basic_session_run_hooks
 from tensorflow.python.training import session_run_hook
 from tensorflow.python.training import training_util
-from tensorflow.python.util.tf_export import estimator_export
 
 from easy_rec.python.utils.config_util import parse_time
 from easy_rec.python.utils.load_class import load_by_path
+
+if LooseVersion(tf.__version__) >= LooseVersion('2.12.0'):
+  from tensorflow_estimator.python.estimator.estimator_export import estimator_export
+else:
+  from tensorflow.python.util.tf_export import estimator_export
 
 _EVENT_FILE_GLOB_PATTERN = 'events.out.tfevents.*'
 

--- a/git-lfs/git_lfs.py
+++ b/git-lfs/git_lfs.py
@@ -238,7 +238,8 @@ if __name__ == '__main__':
       if line_str.startswith('#'):
         continue
       line_str = line_str.replace('~/', os.environ['HOME'] + '/')
-      line_str = line_str.replace('${TMPDIR}', os.environ.get('TMPDIR', '/tmp'))
+      line_str = line_str.replace('${TMPDIR}',
+                                  os.environ.get('TMPDIR', '/tmp/'))
       line_str = line_str.replace('${PROJECT_NAME}', get_proj_name())
       line_tok = [x.strip() for x in line_str.split('=') if x != '']
       if line_tok[0] == 'host':
@@ -373,7 +374,13 @@ if __name__ == '__main__':
               oss_bucket.get_object_to_file(remote_path, tar_tmp_path)
             else:
               url = 'http://%s.%s/%s' % (bucket_name, host, remote_path)
-              subprocess.check_output(['wget', url, '-O', tar_tmp_path])
+              # subprocess.check_output(['wget', url, '-O', tar_tmp_path])
+              if sys.platform.startswith('linux'):
+                subprocess.check_output(['wget', url, '-O', tar_tmp_path])
+              elif sys.platform.startswith('darwin'):
+                subprocess.check_output(['curl', url, '--output', tar_tmp_path])
+              elif sys.platform.startswith('win'):
+                subprocess.check_output(['curl', url, '--output', tar_tmp_path])
           else:
             in_cache = True
             logging.info('%s is in cache' % file_name_with_sig)

--- a/git-lfs/git_lfs.py
+++ b/git-lfs/git_lfs.py
@@ -327,7 +327,6 @@ if __name__ == '__main__':
     any_update = False
     git_bin_arr = load_git_bin()
     git_bin_url = load_git_url()
-    # print('git_bin_arr',git_bin_arr)
     for leaf_path in git_bin_arr:
       leaf_files = git_bin_arr[leaf_path]
       if len(leaf_files) == 0:
@@ -365,7 +364,6 @@ if __name__ == '__main__':
       remote_path = git_bin_url[leaf_path][1]
       _, file_name_with_sig = os.path.split(remote_path)
       tar_tmp_path = '%s/%s.tar.gz' % (git_oss_cache_dir, file_name_with_sig)
-      print('aaa tar_tmp_path', tar_tmp_path)
       max_retry = 5
       while max_retry > 0:
         try:

--- a/git-lfs/git_lfs.py
+++ b/git-lfs/git_lfs.py
@@ -238,7 +238,7 @@ if __name__ == '__main__':
       if line_str.startswith('#'):
         continue
       line_str = line_str.replace('~/', os.environ['HOME'] + '/')
-      line_str = line_str.replace('${TMPDIR}',
+      line_str = line_str.replace('${TMPDIR}/',
                                   os.environ.get('TMPDIR', '/tmp/'))
       line_str = line_str.replace('${PROJECT_NAME}', get_proj_name())
       line_tok = [x.strip() for x in line_str.split('=') if x != '']
@@ -327,6 +327,7 @@ if __name__ == '__main__':
     any_update = False
     git_bin_arr = load_git_bin()
     git_bin_url = load_git_url()
+    # print('git_bin_arr',git_bin_arr)
     for leaf_path in git_bin_arr:
       leaf_files = git_bin_arr[leaf_path]
       if len(leaf_files) == 0:
@@ -364,7 +365,7 @@ if __name__ == '__main__':
       remote_path = git_bin_url[leaf_path][1]
       _, file_name_with_sig = os.path.split(remote_path)
       tar_tmp_path = '%s/%s.tar.gz' % (git_oss_cache_dir, file_name_with_sig)
-
+      print('aaa tar_tmp_path', tar_tmp_path)
       max_retry = 5
       while max_retry > 0:
         try:


### PR DESCRIPTION
1. support macOS and Windows.
   (1) modify `.git_oss_config_pub` -> git_oss_cache_dir , remove signal '/'
   (2) modify `git-lfs/git_lfs.py` -> judge sys.platform, if for MacOS and Windows, use 'curl {url} --output {file}' to download.
2. support `Tensorflow 2.12.0`  -> `early_stopping.py`
   (1) Remove  `estimator_export` in `tensorflow_estimator`.
   (2) Add `estimator_export`  imported from tensorflow_estimator.python.estimator.estimator_export