### PR TITLE
[Bugfix] np.str, np.bool are deprecated in higher version of numpy

### DIFF
--- a/easy_rec/python/core/sampler.py
+++ b/easy_rec/python/core/sampler.py
@@ -47,8 +47,8 @@ def _get_np_type(field_type):
   type_map = {
       DatasetConfig.INT32: np.int32,
       DatasetConfig.INT64: np.int64,
-      DatasetConfig.STRING: np.str,
-      DatasetConfig.BOOL: np.bool,
+      DatasetConfig.STRING: str,
+      DatasetConfig.BOOL: bool,
       DatasetConfig.FLOAT: np.float32,
       DatasetConfig.DOUBLE: np.double
   }
@@ -329,7 +329,7 @@ class NegativeSamplerInMemory(BaseSampler):
     for col_id in range(len(self._attr_np_types)):
       np_type = self._attr_np_types[col_id]
       print('\tcol_id[%d], dtype=%s' % (col_id, self._attr_gl_types[col_id]))
-      if np_type != np.str:
+      if np_type != str:
         self._cols[col_id] = np.array(self._cols[col_id], dtype=np_type)
       else:
         self._cols[col_id] = np.asarray(
@@ -417,7 +417,7 @@ class NegativeSamplerInMemory(BaseSampler):
     for col_id in range(len(self._cols)):
       tmp_col = self._cols[col_id]
       np_type = self._attr_np_types[col_id]
-      if np_type != np.str:
+      if np_type != str:
         sel_feas = tmp_col[sel_ids]
         features.append(sel_feas)
       else:

--- a/easy_rec/python/utils/config_util.py
+++ b/easy_rec/python/utils/config_util.py
@@ -181,7 +181,7 @@ def _get_basic_types():
       bool, int, str, float,
       type(u''), np.float16, np.float32, np.float64, np.char, np.byte, np.uint8,
       np.int8, np.int16, np.uint16, np.uint32, np.int32, np.uint64, np.int64,
-      np.bool, np.str
+      bool, str
   ]
   if six.PY2:
     dtypes.append(long)  # noqa: F821

--- a/easy_rec/python/utils/input_utils.py
+++ b/easy_rec/python/utils/input_utils.py
@@ -80,7 +80,7 @@ def np_to_tf_type(np_type):
       int: tf.int32,
       np.int32: tf.int32,
       np.int64: tf.int64,
-      np.str: tf.string,
+      str: tf.string,
       str: tf.string,
       np.float: tf.float32,
       np.float32: tf.float32,

--- a/easy_rec/python/utils/input_utils.py
+++ b/easy_rec/python/utils/input_utils.py
@@ -81,7 +81,6 @@ def np_to_tf_type(np_type):
       np.int32: tf.int32,
       np.int64: tf.int64,
       str: tf.string,
-      str: tf.string,
       np.float: tf.float32,
       np.float32: tf.float32,
       float: tf.float32,


### PR DESCRIPTION
For NumPy version > 1.20, np.str and np.bool are deprecated, str and bool should be used instead.

Exception message:
AttributeError: module 'numpy' has no attribute 'str'.
`np.str` was a deprecated alias for the builtin `str`. To avoid this error in existing code, use `str` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.str_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations