### PR TITLE
[bugfix] CSV header bug when making local csv prediction on recall models

### DIFF
--- a/docs/source/predict/Local 离线预测.md
+++ b/docs/source/predict/Local 离线预测.md
@@ -26,6 +26,7 @@ CUDA_VISIBLE_DEVICES=0 python -m easy_rec.python.predict --input_path 'data/test
   - 如果有多列，用逗号分割, eg: output_cols='probs double,embedding string'
 - input_sep: 输入文件的分隔符，默认","
 - output_sep: 输出文件的分隔符，默认"\\u0001"
+- with_header: 当输入是csv文件时，可以指定文件是否有表头, 默认false
 
 ### 输出表schema
 

--- a/easy_rec/python/inference/csv_predictor.py
+++ b/easy_rec/python/inference/csv_predictor.py
@@ -24,6 +24,7 @@ class CSVPredictor(Predictor):
   def __init__(self,
                model_path,
                data_config,
+               with_header=False,
                ds_vector_recall=False,
                fg_json_path=None,
                profiling_file=None,
@@ -33,7 +34,7 @@ class CSVPredictor(Predictor):
     self._output_sep = output_sep
     self._ds_vector_recall = ds_vector_recall
     input_type = DatasetConfig.InputType.Name(data_config.input_type).lower()
-    self._with_header = data_config.with_header
+    self._with_header = with_header
 
     if 'rtp' in input_type:
       self._is_rtp = True

--- a/easy_rec/python/predict.py
+++ b/easy_rec/python/predict.py
@@ -30,7 +30,8 @@ logging.basicConfig(
 tf.app.flags.DEFINE_string('input_path', None, 'predict data path')
 tf.app.flags.DEFINE_string('output_path', None, 'path to save predict result')
 tf.app.flags.DEFINE_integer('batch_size', 1024, help='batch size')
-
+tf.app.flags.DEFINE_bool('with_header', False,
+                         'whether the input csv file has header')
 # predict by checkpoint
 tf.app.flags.DEFINE_string('pipeline_config_path', None,
                            'Path to pipeline config '
@@ -119,6 +120,7 @@ def main(argv):
       predictor = CSVPredictor(
           FLAGS.saved_model_dir,
           pipeline_config.data_config,
+          FLAGS.with_header,
           ds_vector_recall=FLAGS.ds_vector_recall,
           fg_json_path=FLAGS.fg_json_path,
           selected_cols=FLAGS.selected_cols,

--- a/easy_rec/python/test/predictor_test.py
+++ b/easy_rec/python/test/predictor_test.py
@@ -180,6 +180,7 @@ class PredictorTestOnDS(tf.test.TestCase):
     predictor = CSVPredictor(
         saved_model_dir,
         pipeline_config.data_config,
+        with_header=True,
         output_sep=';',
         selected_cols='')
 

--- a/easy_rec/python/test/train_eval_test.py
+++ b/easy_rec/python/test/train_eval_test.py
@@ -170,7 +170,7 @@ class TrainEvalTest(tf.test.TestCase):
     self._success = test_utils.test_single_train_eval(
         'samples/model_config/multi_tower_save_secs_on_taobao.config',
         self._test_dir,
-        total_steps=500)
+        total_steps=100)
     ckpts_times = []
     ckpt_dir = os.path.join(self._test_dir, 'train')
     for filepath in os.listdir(ckpt_dir):

--- a/git-lfs/git_lfs.py
+++ b/git-lfs/git_lfs.py
@@ -224,7 +224,7 @@ if __name__ == '__main__':
         'usage: python git_lfs.py [pull] [push] [add filename] [resolve_conflict]'
     )
     sys.exit(1)
-  home_directory = os.path.expanduser("~")
+  home_directory = os.path.expanduser('~')
   with open('.git_oss_config_pub', 'r') as fin:
     git_oss_data_dir = None
     host = None


### PR DESCRIPTION
A bug regarding local prediction on csv file:
The input csv file has no header, after training, the pipeline.config file put with_header property to false.

However, when using two-tower recall model (eg. DSSM, Mind), the splitted tower has different number of input fields. So the input file of prediction has to have header, but easyrec is reading pipeline.config and ignores the header. 

The fix add a command line argument --with_header to allow user specify file format when using local csv prediction.